### PR TITLE
feat(sauna-guide): initial sauna catalog app

### DIFF
--- a/sauna-guide/README.md
+++ b/sauna-guide/README.md
@@ -1,0 +1,50 @@
+# Sauna Guide
+
+サウナ紹介ミニサイト。静的データを検索・絞り込みし、モーダルで詳細を表示する超ミニアプリ。
+
+## 機能
+- 施設一覧表示（名称、都道府県、サウナ温度、水風呂温度、主要設備タグ、★評価）
+- キーワード/都道府県/★評価で検索・絞り込み
+- カードクリックで詳細モーダル表示（説明、住所、営業時間、料金）
+
+## セットアップ
+```bash
+npm i
+npm run dev
+npm run build
+npm run preview
+npm run test
+```
+
+## ディレクトリ構成
+```
+sauna-guide/
+├─ index.html
+├─ package.json
+├─ tsconfig.json
+├─ vite.config.ts
+├─ README.md
+├─ src/
+│  ├─ main.tsx
+│  ├─ App.tsx
+│  ├─ types.ts
+│  ├─ data/saunas.ts
+│  ├─ components/
+│  │  ├─ SearchBar.tsx
+│  │  ├─ SaunaCard.tsx
+│  │  ├─ Modal.tsx
+│  │  └─ RatingStars.tsx
+│  ├─ pages/
+│  │  └─ Home.tsx
+│  └─ styles/
+│     └─ app.module.css
+└─ tests/
+   └─ App.test.tsx
+```
+
+## データの追加
+`src/data/saunas.ts` に `Sauna` 型に沿って追加してください。
+
+## 既知の制限と今後の拡張
+- 画像や地図などは未対応
+- 外部API連携、詳細ページ分割、地図表示などが今後の拡張例です。

--- a/sauna-guide/index.html
+++ b/sauna-guide/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sauna Guide</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/sauna-guide/package.json
+++ b/sauna-guide/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "sauna-guide",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest --environment jsdom"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/sauna-guide/src/App.tsx
+++ b/sauna-guide/src/App.tsx
@@ -1,0 +1,5 @@
+import Home from './pages/Home';
+
+export default function App() {
+  return <Home />;
+}

--- a/sauna-guide/src/components/Modal.tsx
+++ b/sauna-guide/src/components/Modal.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { Sauna } from '../types';
+import styles from '../styles/app.module.css';
+
+interface Props {
+  sauna: Sauna | null;
+  onClose: () => void;
+}
+
+export default function Modal({ sauna, onClose }: Props) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  if (!sauna) return null;
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button onClick={onClose} aria-label="close">
+          ×
+        </button>
+        <h2>{sauna.name}</h2>
+        <p>{sauna.description}</p>
+        <p>
+          <strong>住所:</strong> {sauna.address}
+        </p>
+        <p>
+          <strong>営業時間:</strong> {sauna.hours}
+        </p>
+        <p>
+          <strong>料金:</strong> {sauna.priceRange}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/sauna-guide/src/components/RatingStars.tsx
+++ b/sauna-guide/src/components/RatingStars.tsx
@@ -1,0 +1,14 @@
+import styles from '../styles/app.module.css';
+
+interface Props {
+  rating: number;
+}
+
+export default function RatingStars({ rating }: Props) {
+  const filled = Math.round(rating);
+  return (
+    <span className={styles.stars} aria-label={`評価 ${rating.toFixed(1)}`}>
+      {'★'.repeat(filled)}{'☆'.repeat(5 - filled)}
+    </span>
+  );
+}

--- a/sauna-guide/src/components/SaunaCard.tsx
+++ b/sauna-guide/src/components/SaunaCard.tsx
@@ -1,0 +1,26 @@
+import { Sauna } from '../types';
+import RatingStars from './RatingStars';
+import styles from '../styles/app.module.css';
+
+interface Props {
+  sauna: Sauna;
+  onSelect: (s: Sauna) => void;
+}
+
+export default function SaunaCard({ sauna, onSelect }: Props) {
+  return (
+    <button
+      className={styles.card}
+      onClick={() => onSelect(sauna)}
+      aria-label={`${sauna.name}の詳細`}
+    >
+      <h3>{sauna.name}</h3>
+      <p>{sauna.prefecture}</p>
+      <p>
+        サウナ {sauna.saunaTemp}℃ / 水風呂 {sauna.coldBathTemp}℃
+      </p>
+      <RatingStars rating={sauna.rating} />
+      <p>{sauna.amenities.join(', ')}</p>
+    </button>
+  );
+}

--- a/sauna-guide/src/components/SearchBar.tsx
+++ b/sauna-guide/src/components/SearchBar.tsx
@@ -1,0 +1,55 @@
+import styles from '../styles/app.module.css';
+
+interface Props {
+  keyword: string;
+  prefecture: string;
+  rating: number;
+  prefectures: string[];
+  onKeywordChange: (v: string) => void;
+  onPrefectureChange: (v: string) => void;
+  onRatingChange: (v: number) => void;
+}
+
+export default function SearchBar({
+  keyword,
+  prefecture,
+  rating,
+  prefectures,
+  onKeywordChange,
+  onPrefectureChange,
+  onRatingChange
+}: Props) {
+  return (
+    <div className={styles.searchBar}>
+      <input
+        aria-label="キーワード"
+        type="text"
+        value={keyword}
+        placeholder="キーワード"
+        onChange={(e) => onKeywordChange(e.target.value)}
+      />
+      <select
+        aria-label="都道府県"
+        value={prefecture}
+        onChange={(e) => onPrefectureChange(e.target.value)}
+      >
+        <option value="">全ての都道府県</option>
+        {prefectures.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <input
+        aria-label="最低評価"
+        type="number"
+        min="0"
+        max="5"
+        step="0.1"
+        value={rating}
+        placeholder="評価"
+        onChange={(e) => onRatingChange(parseFloat(e.target.value) || 0)}
+      />
+    </div>
+  );
+}

--- a/sauna-guide/src/data/saunas.ts
+++ b/sauna-guide/src/data/saunas.ts
@@ -1,0 +1,108 @@
+import { Sauna } from '../types';
+
+export const saunas: Sauna[] = [
+  {
+    id: 1,
+    name: '渋谷サウナ',
+    prefecture: '東京都',
+    saunaTemp: 95,
+    coldBathTemp: 15,
+    rating: 4.5,
+    amenities: ['ロウリュ', '外気浴'],
+    description: '渋谷駅近くの都会型サウナ。',
+    address: '東京都渋谷区1-2-3',
+    hours: '10:00-23:00',
+    priceRange: '¥1,200〜'
+  },
+  {
+    id: 2,
+    name: '新宿ヒート',
+    prefecture: '東京都',
+    saunaTemp: 90,
+    coldBathTemp: 16,
+    rating: 4.0,
+    amenities: ['TV', '休憩スペース'],
+    description: '新宿で人気の大型サウナ施設。',
+    address: '東京都新宿区4-5-6',
+    hours: '24時間',
+    priceRange: '¥1,000〜'
+  },
+  {
+    id: 3,
+    name: '大阪リラックス',
+    prefecture: '大阪府',
+    saunaTemp: 92,
+    coldBathTemp: 14,
+    rating: 4.1,
+    amenities: ['ロウリュ', '食事処'],
+    description: '大阪の中心部でゆったりと。',
+    address: '大阪府大阪市1-2-3',
+    hours: '9:00-25:00',
+    priceRange: '¥1,100〜'
+  },
+  {
+    id: 4,
+    name: '北海道チル',
+    prefecture: '北海道',
+    saunaTemp: 98,
+    coldBathTemp: 10,
+    rating: 4.2,
+    amenities: ['雪ダイブ', '外気浴'],
+    description: '極寒の地ならではの体験。',
+    address: '北海道札幌市1-2-3',
+    hours: '8:00-22:00',
+    priceRange: '¥1,300〜'
+  },
+  {
+    id: 5,
+    name: '福岡スチーム',
+    prefecture: '福岡県',
+    saunaTemp: 88,
+    coldBathTemp: 17,
+    rating: 3.9,
+    amenities: ['サウナ飯', 'マッサージ'],
+    description: '博多駅から徒歩5分。',
+    address: '福岡県福岡市1-2-3',
+    hours: '10:00-24:00',
+    priceRange: '¥900〜'
+  },
+  {
+    id: 6,
+    name: '京都禅サウナ',
+    prefecture: '京都府',
+    saunaTemp: 85,
+    coldBathTemp: 18,
+    rating: 3.8,
+    amenities: ['瞑想室'],
+    description: '静寂に包まれた和風サウナ。',
+    address: '京都府京都市1-2-3',
+    hours: '12:00-22:00',
+    priceRange: '¥1,000〜'
+  },
+  {
+    id: 7,
+    name: '名古屋ヒート',
+    prefecture: '愛知県',
+    saunaTemp: 94,
+    coldBathTemp: 13,
+    rating: 4.1,
+    amenities: ['TV', '外気浴'],
+    description: '名古屋の定番サウナ。',
+    address: '愛知県名古屋市1-2-3',
+    hours: '11:00-23:00',
+    priceRange: '¥1,050〜'
+  },
+  {
+    id: 8,
+    name: '神戸ハーバーサウナ',
+    prefecture: '兵庫県',
+    saunaTemp: 93,
+    coldBathTemp: 12,
+    rating: 4.3,
+    amenities: ['ロウリュ', '海風外気浴'],
+    description: '港の風を感じるサウナ。',
+    address: '兵庫県神戸市1-2-3',
+    hours: '10:00-23:00',
+    priceRange: '¥1,200〜'
+  }
+];

--- a/sauna-guide/src/main.tsx
+++ b/sauna-guide/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/app.module.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/sauna-guide/src/pages/Home.tsx
+++ b/sauna-guide/src/pages/Home.tsx
@@ -1,0 +1,52 @@
+import { useState, useMemo } from 'react';
+import { saunas } from '../data/saunas';
+import SearchBar from '../components/SearchBar';
+import SaunaCard from '../components/SaunaCard';
+import Modal from '../components/Modal';
+import { Sauna } from '../types';
+import styles from '../styles/app.module.css';
+
+export default function Home() {
+  const [keyword, setKeyword] = useState('');
+  const [prefecture, setPrefecture] = useState('');
+  const [rating, setRating] = useState(0);
+  const [selected, setSelected] = useState<Sauna | null>(null);
+
+  const prefectures = useMemo(
+    () => Array.from(new Set(saunas.map((s) => s.prefecture))),
+    []
+  );
+
+  const filtered = useMemo(
+    () =>
+      saunas.filter(
+        (s) =>
+          (keyword === '' ||
+            s.name.includes(keyword) ||
+            s.description.includes(keyword)) &&
+          (prefecture === '' || s.prefecture === prefecture) &&
+          (rating === 0 || s.rating >= rating)
+      ),
+    [keyword, prefecture, rating]
+  );
+
+  return (
+    <div className={styles.container}>
+      <SearchBar
+        keyword={keyword}
+        prefecture={prefecture}
+        rating={rating}
+        prefectures={prefectures}
+        onKeywordChange={setKeyword}
+        onPrefectureChange={setPrefecture}
+        onRatingChange={setRating}
+      />
+      <div className={styles.grid}>
+        {filtered.map((s) => (
+          <SaunaCard key={s.id} sauna={s} onSelect={setSelected} />
+        ))}
+      </div>
+      <Modal sauna={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
+}

--- a/sauna-guide/src/styles/app.module.css
+++ b/sauna-guide/src/styles/app.module.css
@@ -1,0 +1,46 @@
+.container {
+  padding: 1rem;
+  font-family: sans-serif;
+}
+.searchBar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+.card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  background: #fff;
+  text-align: left;
+}
+.stars {
+  color: #f5a623;
+}
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  max-width: 400px;
+  width: 90%;
+}
+.modal button {
+  float: right;
+}

--- a/sauna-guide/src/types.ts
+++ b/sauna-guide/src/types.ts
@@ -1,0 +1,13 @@
+export interface Sauna {
+  id: number;
+  name: string;
+  prefecture: string;
+  saunaTemp: number;
+  coldBathTemp: number;
+  rating: number;
+  amenities: string[];
+  description: string;
+  address: string;
+  hours: string;
+  priceRange: string;
+}

--- a/sauna-guide/tests/App.test.tsx
+++ b/sauna-guide/tests/App.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from '../src/App';
+import { saunas } from '../src/data/saunas';
+import '@testing-library/jest-dom';
+
+test('renders list', () => {
+  render(<App />);
+  const cards = screen.getAllByRole('button');
+  expect(cards).toHaveLength(saunas.length);
+});
+
+test('keyword filter', () => {
+  render(<App />);
+  fireEvent.change(screen.getByLabelText('キーワード'), {
+    target: { value: '渋谷' }
+  });
+  const cards = screen.getAllByRole('button');
+  expect(cards).toHaveLength(1);
+  expect(screen.getByText('渋谷サウナ')).toBeInTheDocument();
+});
+
+test('prefecture filter', () => {
+  render(<App />);
+  fireEvent.change(screen.getByLabelText('都道府県'), {
+    target: { value: '東京都' }
+  });
+  const count = saunas.filter((s) => s.prefecture === '東京都').length;
+  const cards = screen.getAllByRole('button');
+  expect(cards).toHaveLength(count);
+});
+
+test('rating filter', () => {
+  render(<App />);
+  fireEvent.change(screen.getByLabelText('最低評価'), {
+    target: { value: '4.0' }
+  });
+  const count = saunas.filter((s) => s.rating >= 4.0).length;
+  expect(screen.getAllByRole('button')).toHaveLength(count);
+});
+
+test('modal open/close', () => {
+  render(<App />);
+  const first = screen.getAllByRole('button')[0];
+  fireEvent.click(first);
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText('close'));
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});

--- a/sauna-guide/tsconfig.json
+++ b/sauna-guide/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": false,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/sauna-guide/vite.config.ts
+++ b/sauna-guide/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Purpose
- add a minimal React + TypeScript sauna catalog

## Screenshots
- (top) *screenshot omitted*
- (modal) *screenshot omitted*

## Implementation
- scaffolded Vite + React + TS app under `sauna-guide/`
- static sauna dataset and reusable UI components
- keyword/prefecture/rating filters with modal detail view

## Verification
- `npm run dev` *(vite: not found)*
- `npm test` *(vitest: not found)*

## Impact
- new folder `sauna-guide` only


------
https://chatgpt.com/codex/tasks/task_e_68a5f5e2d04c832ea300535f190d868f